### PR TITLE
feat(search): Add recent searches functionality with dedicated hook

### DIFF
--- a/src/components/JackettSearch.tsx
+++ b/src/components/JackettSearch.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { useEventSource } from "../hooks/useEventSource";
 import { useIndexers } from "../hooks/useIndexers";
 import { useLocalStorage } from "../hooks/usePersistentState";
+import { useRecentSearches } from "../hooks/useRecentSearches";
 import { useResultBatching } from "../hooks/useResultBatching";
 import { useSearch } from "../hooks/useSearch";
 import { useSearchCache } from "../hooks/useSearchCache";
@@ -29,6 +30,9 @@ const JackettSearch = memo(() => {
 
   // Search cache
   const { getCachedResults, setCachedResults } = useSearchCache();
+
+  // Recent searches
+  const { addToRecentSearches } = useRecentSearches();
 
   // Indexer management
   const {
@@ -70,6 +74,9 @@ const JackettSearch = memo(() => {
   // Wrapper function to match the expected signature
   const fetchDataJackettWrapper = () => {
     const query = inputRef.current?.value || "";
+    if (query.trim()) {
+      addToRecentSearches(query.trim());
+    }
     fetchDataJackett(query);
   };
 

--- a/src/components/SearchSuggestions.tsx
+++ b/src/components/SearchSuggestions.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
-
 import { Clock, Search, X } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+
+import { useRecentSearches } from "../hooks/useRecentSearches";
 
 interface SearchSuggestionsProps {
   onSuggestionClick: (suggestion: string) => void;
@@ -15,7 +15,7 @@ export function SearchSuggestions({
   onSuggestionClick,
   className = "",
 }: SearchSuggestionsProps) {
-  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const { recentSearches, removeFromRecentSearches } = useRecentSearches();
 
   // Popular search suggestions
   const popularSuggestions = [
@@ -31,36 +31,7 @@ export function SearchSuggestions({
     "REMUX",
   ];
 
-  useEffect(() => {
-    // Load recent searches from localStorage
-    const stored = localStorage.getItem("jackett-recent-searches");
-    if (stored) {
-      try {
-        const parsed = JSON.parse(stored);
-        setRecentSearches(Array.isArray(parsed) ? parsed.slice(0, 5) : []);
-      } catch (error) {
-        console.error("Error parsing recent searches:", error);
-      }
-    }
-  }, []);
-
-  const addToRecentSearches = (query: string) => {
-    const updated = [query, ...recentSearches.filter((s) => s !== query)].slice(
-      0,
-      5
-    );
-    setRecentSearches(updated);
-    localStorage.setItem("jackett-recent-searches", JSON.stringify(updated));
-  };
-
-  const removeFromRecentSearches = (query: string) => {
-    const updated = recentSearches.filter((s) => s !== query);
-    setRecentSearches(updated);
-    localStorage.setItem("jackett-recent-searches", JSON.stringify(updated));
-  };
-
   const handleSuggestionClick = (suggestion: string) => {
-    addToRecentSearches(suggestion);
     onSuggestionClick(suggestion);
   };
 

--- a/src/hooks/useRecentSearches.ts
+++ b/src/hooks/useRecentSearches.ts
@@ -1,0 +1,45 @@
+import { useCallback } from "react";
+
+import { usePersistentState } from "./usePersistentState";
+
+export function useRecentSearches() {
+  const [recentSearches, setRecentSearches] = usePersistentState<string[]>(
+    "jackett-recent-searches",
+    [],
+    localStorage
+  );
+
+  const addToRecentSearches = useCallback(
+    (query: string) => {
+      setRecentSearches((prev) => {
+        // Remove the query if it already exists to avoid duplicates
+        const filtered = prev.filter(
+          (s) => s.toLowerCase() !== query.toLowerCase()
+        );
+        // Add the new query to the beginning and keep only the last 5
+        return [query, ...filtered].slice(0, 5);
+      });
+    },
+    [setRecentSearches]
+  );
+
+  const removeFromRecentSearches = useCallback(
+    (query: string) => {
+      setRecentSearches((prev) =>
+        prev.filter((s) => s.toLowerCase() !== query.toLowerCase())
+      );
+    },
+    [setRecentSearches]
+  );
+
+  const clearRecentSearches = useCallback(() => {
+    setRecentSearches([]);
+  }, [setRecentSearches]);
+
+  return {
+    recentSearches,
+    addToRecentSearches,
+    removeFromRecentSearches,
+    clearRecentSearches,
+  };
+}


### PR DESCRIPTION
- Create useRecentSearches hook for managing search history
- Implement addToRecentSearches in JackettSearch component
- Replace local state management with the new hook in SearchSuggestions
- Store recent searches in localStorage with max 5 entries
- Add case-insensitive duplicate prevention