### PR TITLE
refactor(ui): revert custom colors and gradients to default shadcn/ui styling

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,12 +5,12 @@ import { ThemeToggle } from "./ThemeToggle";
 
 export function Header() {
   return (
-    <div className="flex flex-col gap-6 sm:gap-8 animate-fadeIn mb-8">
+    <div className="flex flex-col gap-6 sm:gap-8 mb-8">
       {/* Main header row */}
       <div className="flex items-center justify-between max-w-5xl mx-auto w-full px-2">
         <div className="flex gap-4 items-center min-w-0 flex-1 group cursor-default">
           <div className="relative">
-            <div className="absolute -inset-1 bg-gradient-to-r from-primary to-cyan-600 rounded-full blur opacity-25 group-hover:opacity-50 transition duration-500"></div>
+            <div className="absolute -inset-1 bg-primary/20 rounded-full blur opacity-25 group-hover:opacity-50 transition duration-500"></div>
             <img
               src={jackettLogo}
               alt="jackett logo"
@@ -18,7 +18,7 @@ export function Header() {
             />
           </div>
           <div className="flex flex-col">
-            <h1 className="text-xl sm:text-2xl font-black tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-primary to-cyan-600 dark:from-white dark:to-primary/50 transition-all duration-300">
+            <h1 className="text-xl sm:text-2xl font-black tracking-tight text-foreground transition-all duration-300">
               Jackett Search
             </h1>
             <p className="text-[10px] uppercase tracking-widest text-muted-foreground font-semibold">

--- a/src/components/IndexerChips.tsx
+++ b/src/components/IndexerChips.tsx
@@ -33,7 +33,7 @@ export function IndexerChips({
   })();
 
   return (
-    <div className="flex flex-wrap items-center gap-3 p-4 bg-background/20 backdrop-blur-md rounded-2xl border border-border/80">
+    <div className="flex flex-wrap items-center gap-3 p-4 bg-muted rounded-lg border border-border">
       <div className="flex items-center gap-2 mr-2">
         <span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
           Filter by:

--- a/src/components/IndexerSelector.tsx
+++ b/src/components/IndexerSelector.tsx
@@ -77,7 +77,7 @@ export function IndexerSelector({
   }
 
   return (
-    <Card className="border-border bg-background/40 backdrop-blur-xl shadow-sm rounded-2xl overflow-hidden transition-all duration-500 animate-fadeIn">
+    <Card className="border-border bg-background shadow-sm rounded-lg overflow-hidden">
       <CardHeader className="pb-3 border-b border-border/20">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
@@ -110,10 +110,10 @@ export function IndexerSelector({
             }
             size="sm"
             onClick={() => handleModeChange("all")}
-            className={`flex-1 flex items-center justify-center gap-2 h-9 rounded-xl transition-all duration-300 ${
+            className={`flex-1 flex items-center justify-center gap-2 h-9 rounded-md transition-all duration-300 ${
               selectionState.searchMode === "all"
-                ? "bg-gradient-to-r from-primary to-cyan-600 border-none text-white font-semibold"
-                : "border-border/50 hover:border-primary/30 hover:bg-primary/5"
+                ? "bg-primary border-none text-primary-foreground font-semibold"
+                : "border-border hover:border-ring hover:bg-accent"
             }`}
           >
             <Search className="h-3.5 w-3.5" />
@@ -125,10 +125,10 @@ export function IndexerSelector({
             }
             size="sm"
             onClick={() => handleModeChange("selected")}
-            className={`flex-1 flex items-center justify-center gap-2 h-9 rounded-xl transition-all duration-300 ${
+            className={`flex-1 flex items-center justify-center gap-2 h-9 rounded-md transition-all duration-300 ${
               selectionState.searchMode === "selected"
-                ? "bg-gradient-to-r from-primary to-cyan-600 border-none text-white font-semibold"
-                : "border-border/50 hover:border-primary/30 hover:bg-primary/5"
+                ? "bg-primary border-none text-primary-foreground font-semibold"
+                : "border-border hover:border-ring hover:bg-accent"
             }`}
             disabled={selectionState.selectedIndexers.length === 0}
           >
@@ -154,7 +154,7 @@ export function IndexerSelector({
                   placeholder="Filter indexers..."
                   value={searchFilter}
                   onChange={(e) => setSearchFilter(e.target.value)}
-                  className="h-10 pl-10 bg-secondary/20 border-border/40 focus:border-primary/50 focus:ring-primary/10 transition-all rounded-xl"
+                  className="h-10 pl-10 bg-accent border border-border focus:border-ring focus:ring-2 focus:ring-ring transition-all rounded-md"
                 />
                 <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground group-focus-within:text-primary transition-colors" />
               </div>
@@ -163,7 +163,7 @@ export function IndexerSelector({
                   variant="outline"
                   size="sm"
                   onClick={handleSelectAll}
-                  className="px-4 bg-secondary/10 border-border/40 hover:border-primary/30 hover:bg-primary/10 rounded-xl transition-all font-medium text-xs"
+                  className="px-4 bg-secondary border border-border hover:border-ring hover:bg-accent rounded-md transition-all font-medium text-xs"
                 >
                   All
                 </Button>
@@ -171,7 +171,7 @@ export function IndexerSelector({
                   variant="outline"
                   size="sm"
                   onClick={handleSelectNone}
-                  className="px-4 bg-secondary/10 border-border/40 hover:border-primary/30 hover:bg-primary/10 rounded-xl transition-all font-medium text-xs"
+                  className="px-4 bg-secondary border border-border hover:border-ring hover:bg-accent rounded-md transition-all font-medium text-xs"
                 >
                   None
                 </Button>
@@ -190,10 +190,10 @@ export function IndexerSelector({
                       key={indexer.id}
                       role="button"
                       tabIndex={0}
-                      className={`flex items-center justify-between p-3 rounded-xl border transition-all duration-300 ${
+                      className={`flex items-center justify-between p-3 rounded-md border transition-all ${
                         isSelected
-                          ? "bg-primary/10 border-primary/40 scale-[1.01]"
-                          : "bg-secondary/10 border-transparent hover:border-primary/30 hover:bg-secondary/20"
+                          ? "bg-primary/10 border-primary"
+                          : "bg-muted/50 border-transparent hover:border-ring hover:bg-muted"
                       }`}
                       onClick={() => handleIndexerToggle(indexer.id)}
                       onKeyDown={(e) => {
@@ -205,18 +205,18 @@ export function IndexerSelector({
                     >
                       <div className="flex items-center gap-3 flex-1 min-w-0">
                         <div
-                          className={`w-5 h-5 rounded-md border-2 flex items-center justify-center transition-all duration-300 ${
+                          className={`w-5 h-5 rounded-md border-2 flex items-center justify-center transition-all ${
                             isSelected
                               ? "bg-primary border-primary"
                               : "border-muted-foreground/30"
                           }`}
                         >
                           {isSelected && (
-                            <Check className="h-3.5 w-3.5 text-primary-foreground stroke-[3px] animate-scaleIn" />
+                            <Check className="h-3.5 w-3.5 text-primary-foreground stroke-[3px]" />
                           )}
                         </div>
                         <span
-                          className={`text-sm font-medium truncate transition-colors ${isSelected ? "text-primary" : "text-foreground/90"}`}
+                          className={`text-sm font-medium truncate ${isSelected ? "text-primary" : "text-foreground"}`}
                         >
                           {indexer.id}
                         </span>
@@ -244,7 +244,7 @@ export function IndexerSelector({
                     <Badge
                       key={id}
                       variant="outline"
-                      className="px-3 py-1 bg-primary/10 border-primary/20 text-primary font-bold text-[10px] hover:bg-primary/20 transition-all rounded-full"
+                      className="px-3 py-1 bg-primary/10 border-primary/20 text-primary font-bold text-[10px] rounded-full"
                     >
                       {id}
                     </Badge>
@@ -252,7 +252,7 @@ export function IndexerSelector({
                   {selectionState.selectedIndexers.length > 15 && (
                     <Badge
                       variant="outline"
-                      className="px-3 py-1 bg-secondary/20 border-border/50 text-[10px] font-bold text-muted-foreground rounded-full"
+                      className="px-3 py-1 bg-muted border-border text-muted-foreground text-[10px] font-bold rounded-full"
                     >
                       +{selectionState.selectedIndexers.length - 15} MORE
                     </Badge>

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -122,7 +122,7 @@ export function ResultsTable({
   if (results.length === 0) return null;
 
   return (
-    <Card className="border-border bg-background/40 backdrop-blur-xl shadow-sm rounded-2xl overflow-hidden animate-fadeIn">
+    <Card className="border-border bg-background shadow-sm rounded-lg overflow-hidden">
       <CardHeader className="pb-3 border-b border-border/20">
         <div className="flex flex-col gap-6">
           <div className="flex items-center justify-between">
@@ -143,7 +143,7 @@ export function ResultsTable({
             <select
               value={itemsPerPage}
               onChange={(e) => setItemsPerPage(Number(e.target.value))}
-              className="h-10 px-4 bg-secondary/20 border-border/40 text-sm font-medium rounded-xl hover:bg-secondary/30 transition-all focus:ring-primary/20 cursor-pointer w-full sm:w-auto"
+              className="h-10 px-4 bg-secondary/20 border-border text-sm font-medium rounded-lg hover:bg-secondary/30 transition-all focus:ring-ring cursor-pointer w-full sm:w-auto"
             >
               {[25, 50, 100, 200].map((val) => (
                 <option key={val} value={val}>
@@ -157,7 +157,7 @@ export function ResultsTable({
                 placeholder="Fuzzy filter results (e.g. '720p season 1')..."
                 value={filter}
                 onChange={(e) => setFilter(e.target.value)}
-                className="h-10 pl-10 bg-secondary/20 border-border/80 rounded-xl transition-all duration-300 focus:ring-2 focus:ring-primary/20 focus:border-primary/50 text-lg shadow-sm"
+                className="h-10 pl-10 bg-secondary/20 border-border rounded-md transition-all duration-300 focus:ring-2 focus:ring-ring focus:border-ring"
               />
               <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground group-focus-within:text-primary transition-colors" />
               {filter && (

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -55,7 +55,7 @@ export const SearchForm = forwardRef<HTMLInputElement, SearchFormProps>(
             <div className="flex-1 w-full relative group">
               <Input
                 ref={ref}
-                className="relative w-full h-12 pr-12 bg-background/80 backdrop-blur-xl border-border/80 rounded-xl transition-all duration-300 focus:ring-2 focus:ring-primary/20 focus:border-primary/50 hover:border-primary/30 text-lg shadow-sm"
+                className="relative w-full h-12 pr-12 bg-background border border-border rounded-md transition-all duration-300 focus:ring-2 focus:ring-ring text-lg"
                 placeholder="Search for movies, TV shows, or anything..."
                 disabled={loading}
                 value={value}
@@ -87,7 +87,7 @@ export const SearchForm = forwardRef<HTMLInputElement, SearchFormProps>(
                   e.preventDefault();
                   onCancel();
                 }}
-                className="w-full sm:w-auto h-12 px-8 border-destructive/30 text-destructive bg-destructive/5 hover:bg-destructive/10 backdrop-blur-sm transition-all duration-300 rounded-xl"
+                className="w-full sm:w-auto h-12 px-8 border-destructive/30 text-destructive bg-destructive/5 hover:bg-destructive/10 transition-all duration-300 rounded-md"
               >
                 <Loader2 className="w-5 h-5 mr-3 animate-spin" />
                 Cancel
@@ -96,7 +96,7 @@ export const SearchForm = forwardRef<HTMLInputElement, SearchFormProps>(
               <Button
                 variant="default"
                 type="submit"
-                className="w-full sm:w-auto h-12 px-8 transition-all duration-300 hover:scale-[1.02] active:scale-95 bg-gradient-to-r from-primary to-cyan-600 hover:from-primary/90 hover:to-cyan-600/90 text-white font-semibold rounded-xl"
+                className="w-full sm:w-auto h-12 px-8 transition-all duration-300 hover:scale-[1.02] active:scale-95 bg-primary hover:bg-primary/90 text-primary-foreground font-semibold rounded-md"
               >
                 <Search className="w-5 h-5 mr-3" />
                 Search
@@ -106,7 +106,7 @@ export const SearchForm = forwardRef<HTMLInputElement, SearchFormProps>(
         </form>
 
         {showSuggestions && showSuggestionsPanel && (
-          <div className="mt-4 animate-fadeIn">
+          <div className="mt-4">
             <SearchSuggestions onSuggestionClick={handleSuggestionClick} />
           </div>
         )}

--- a/src/components/SearchSuggestions.tsx
+++ b/src/components/SearchSuggestions.tsx
@@ -44,22 +44,22 @@ export function SearchSuggestions({
           {recentSearches.length > 0 && (
             <div>
               <div className="flex items-center gap-3 mb-4 group/header">
-                <div className="p-2 bg-primary/10 rounded-lg group-hover/header:bg-primary/20 transition-colors duration-300">
-                  <Clock className="h-4 w-4 text-primary" />
+                <div className="p-2 bg-muted rounded-lg group-hover/header:bg-muted transition-colors duration-300">
+                  <Clock className="h-4 w-4 text-foreground" />
                 </div>
                 <span className="text-sm font-bold tracking-tight text-foreground/80 uppercase text-[11px]">
                   Recent Activity
                 </span>
-                <div className="h-[1px] flex-1 bg-gradient-to-r from-border/50 to-transparent"></div>
+                <div className="h-[1px] flex-1 bg-border" />
               </div>
               <div className="flex flex-wrap gap-2.5">
                 {recentSearches.map((search, index) => (
                   <div key={index} className="group relative">
                     <div
-                      className="flex items-center gap-2 pl-4 pr-2 py-2 bg-secondary/30 hover:bg-secondary/60 backdrop-blur-md border border-border/50 rounded-full cursor-pointer transition-all duration-300 hover:scale-105 hover:shadow-lg hover:border-primary/30"
+                      className="flex items-center gap-2 pl-4 pr-2 py-2 bg-muted/50 hover:bg-muted border border-border rounded-full cursor-pointer transition-all duration-300"
                       onClick={() => handleSuggestionClick(search)}
                     >
-                      <span className="text-sm font-medium text-foreground/90 max-w-[150px] truncate">
+                      <span className="text-sm font-medium text-foreground max-w-[150px] truncate">
                         {search}
                       </span>
                       <Button
@@ -83,19 +83,19 @@ export function SearchSuggestions({
           {/* Popular Suggestions section */}
           <div>
             <div className="flex items-center gap-3 mb-4 group/header">
-              <div className="p-2 bg-primary/10 rounded-lg group-hover/header:bg-primary/20 transition-colors duration-300">
-                <Search className="h-4 w-4 text-primary" />
+              <div className="p-2 bg-muted rounded-lg group-hover/header:bg-muted transition-colors duration-300">
+                <Search className="h-4 w-4 text-foreground" />
               </div>
               <span className="text-sm font-bold tracking-tight text-foreground/80 uppercase text-[11px]">
                 Trending Topics
               </span>
-              <div className="h-[1px] flex-1 bg-gradient-to-r from-border/50 to-transparent"></div>
+              <div className="h-[1px] flex-1 bg-border" />
             </div>
             <div className="flex flex-wrap gap-2.5">
               {popularSuggestions.map((suggestion, index) => (
                 <div
                   key={index}
-                  className="px-4 py-2 bg-primary/5 hover:bg-primary/10 backdrop-blur-sm border border-primary/10 hover:border-primary/30 rounded-full cursor-pointer transition-all duration-300 hover:scale-105 hover:shadow-md text-sm font-medium text-primary/80 hover:text-primary"
+                  className="px-4 py-2 bg-muted border border-border rounded-full cursor-pointer transition-all duration-300 text-sm font-medium text-foreground"
                   onClick={() => handleSuggestionClick(suggestion)}
                 >
                   {suggestion}

--- a/src/components/SearchSuggestions.tsx
+++ b/src/components/SearchSuggestions.tsx
@@ -36,13 +36,13 @@ export function SearchSuggestions({
 
   return (
     <Card
-      className={`border-border/40 bg-background/40 backdrop-blur-xl shadow-2xl rounded-2xl overflow-hidden transition-all duration-500 ${className}`}
+      className={`border-border bg-background shadow rounded-lg overflow-hidden ${className}`}
     >
       <CardContent className="p-6">
         <div className="space-y-8">
           {/* Recent Searches section */}
           {recentSearches.length > 0 && (
-            <div className="animate-slideDown">
+            <div>
               <div className="flex items-center gap-3 mb-4 group/header">
                 <div className="p-2 bg-primary/10 rounded-lg group-hover/header:bg-primary/20 transition-colors duration-300">
                   <Clock className="h-4 w-4 text-primary" />
@@ -81,10 +81,10 @@ export function SearchSuggestions({
           )}
 
           {/* Popular Suggestions section */}
-          <div className="animate-slideUp">
+          <div>
             <div className="flex items-center gap-3 mb-4 group/header">
-              <div className="p-2 bg-cyan-600/10 rounded-lg group-hover/header:bg-cyan-600/20 transition-colors duration-300">
-                <Search className="h-4 w-4 text-cyan-600" />
+              <div className="p-2 bg-primary/10 rounded-lg group-hover/header:bg-primary/20 transition-colors duration-300">
+                <Search className="h-4 w-4 text-primary" />
               </div>
               <span className="text-sm font-bold tracking-tight text-foreground/80 uppercase text-[11px]">
                 Trending Topics

--- a/src/components/results/ResultsMobileCard.tsx
+++ b/src/components/results/ResultsMobileCard.tsx
@@ -19,7 +19,7 @@ export function ResultsMobileCard({ result, onCopy }: ResultsMobileCardProps) {
   };
 
   return (
-    <div className="p-2.5 border-b hover:bg-muted/50 flex flex-col gap-1.5 transition-colors active:bg-muted/30 animate-slideUp">
+    <div className="p-2.5 border-b hover:bg-muted/50 flex flex-col gap-1.5 transition-colors active:bg-muted/30">
       <div
         className="font-medium text-foreground/90 break-all leading-snug text-sm"
         title={result.Title}

--- a/src/components/results/ResultsTableRow.tsx
+++ b/src/components/results/ResultsTableRow.tsx
@@ -22,7 +22,7 @@ export function ResultsTableRow({
   };
 
   return (
-    <div className="grid grid-cols-12 gap-2 p-2 border-b hover:bg-muted/50 items-center text-sm min-h-[60px] transition-colors duration-200 group animate-slideUp">
+    <div className="grid grid-cols-12 gap-2 p-2 border-b hover:bg-muted/50 items-center text-sm min-h-[60px] transition-colors duration-200 group">
       <div
         className="col-span-6 font-medium text-foreground/90 break-all"
         title={result.Title}

--- a/src/components/ui/badge-variants.ts
+++ b/src/components/ui/badge-variants.ts
@@ -12,13 +12,6 @@ export const badgeVariants = cva(
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
         outline: "text-foreground",
-        chip: "border-transparent bg-muted text-muted-foreground hover:bg-muted/80 rounded-full px-3 py-1",
-        "chip-seeds":
-          "border-transparent bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400 hover:bg-green-200 dark:hover:bg-green-900/30 rounded-full px-3 py-1",
-        "chip-size":
-          "border-transparent bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/30 rounded-full px-3 py-1",
-        "chip-indexer":
-          "border-transparent bg-purple-100 text-purple-800 dark:bg-purple-900/20 dark:text-purple-400 hover:bg-purple-200 dark:hover:bg-purple-900/30 rounded-full px-3 py-1 gap-1",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
+      "rounded-lg border bg-card text-card-foreground shadow",
       className
     )}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -10,19 +10,19 @@
     --card-foreground: 222.2 84% 4.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
-    --primary: 262.1 83.3% 57.8%;
+    --primary: 222.2 47.4% 50%;
     --primary-foreground: 0 0% 100%;
     --secondary: 220 14.3% 95.9%;
     --secondary-foreground: 220.9 34.4% 14.1%;
     --muted: 220 14.3% 95.9%;
     --muted-foreground: 220 14.3% 41.4%;
-    --accent: 224 13.8% 91.4%;
-    --accent-foreground: 222.2 84% 4.9%;
+    --accent: 220 14.3% 95.9%;
+    --accent-foreground: 220.9 34.4% 14.1%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 100%;
     --border: 220 22% 88%;
     --input: 220 22% 88%;
-    --ring: 262.1 83.3% 57.8%;
+    --ring: 222.2 47.4% 50%;
     --radius: 0.5rem;
   }
 
@@ -33,8 +33,8 @@
     --card-foreground: 210 40% 98%;
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
-    --primary: 263.4 70% 50.4%;
-    --primary-foreground: 0 0% 100%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 14.1%;
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
     --muted: 217.2 32.6% 17.5%;
@@ -45,7 +45,7 @@
     --destructive-foreground: 210 40% 98%;
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
-    --ring: 263.4 70% 50.4%;
+    --ring: 210 40% 98%;
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -4,95 +4,48 @@
 
 @layer base {
   :root {
-    /* Premium Light Theme - Soft Silvers & Slate */
-    --background: 210 20% 98%;
-    --foreground: 222 47% 11%;
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
-    --card-foreground: 222 47% 11%;
+    --card-foreground: 222.2 84% 4.9%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 11%;
-
-    /* Sophisticated Blue Primary */
-    --primary: 217 91% 60%;
-    --primary-foreground: 210 40% 98%;
-
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222 47% 11.2%;
-
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-
-    --accent: 217 91% 60%;
-    --accent-foreground: 222 47% 11.2%;
-
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 262.1 83.3% 57.8%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 220 14.3% 95.9%;
+    --secondary-foreground: 220.9 34.4% 14.1%;
+    --muted: 220 14.3% 95.9%;
+    --muted-foreground: 220 14.3% 41.4%;
+    --accent: 224 13.8% 91.4%;
+    --accent-foreground: 222.2 84% 4.9%;
     --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 217 91% 60%;
-
-    --radius: 1rem;
-
-    --font-geist-sans: "Geist", system-ui, sans-serif;
-    --font-geist-mono: "Geist Mono", monospace;
-
-    /* Gradients */
-    --gradient-primary: linear-gradient(
-      135deg,
-      hsl(217 91% 60%) 0%,
-      hsl(199 89% 55%) 100%
-    );
-
-    --gradient-glass: linear-gradient(
-      135deg,
-      rgba(255, 255, 255, 0.4) 0%,
-      rgba(255, 255, 255, 0.1) 100%
-    );
+    --destructive-foreground: 0 0% 100%;
+    --border: 220 22% 88%;
+    --input: 220 22% 88%;
+    --ring: 262.1 83.3% 57.8%;
+    --radius: 0.5rem;
   }
 
   .dark {
-    /* Premium Dark Theme - Deep Obsidian & Navy */
-    --background: 222 47% 4%;
+    --background: 222.2 84% 4.9%;
     --foreground: 210 40% 98%;
-
-    --card: 222 47% 6%;
+    --card: 222.2 84% 4.9%;
     --card-foreground: 210 40% 98%;
-
-    --popover: 222 47% 4%;
+    --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
-
-    /* Electric Blue Primary */
-    --primary: 217 91% 65%;
-    --primary-foreground: 222 47% 11%;
-
-    --secondary: 222 47% 11%;
+    --primary: 263.4 70% 50.4%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
-
-    --muted: 222 47% 11%;
+    --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;
-
-    --accent: 217 91% 65%;
+    --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
-
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
-
-    --border: 222 47% 11%;
-    --input: 222 47% 11%;
-    --ring: 217 91% 65%;
-
-    --gradient-primary: linear-gradient(
-      135deg,
-      hsl(217 91% 65%) 0%,
-      hsl(199 89% 60%) 100%
-    );
-
-    --gradient-glass: linear-gradient(
-      135deg,
-      rgba(255, 255, 255, 0.05) 0%,
-      rgba(255, 255, 255, 0.01) 100%
-    );
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 263.4 70% 50.4%;
   }
 }
 
@@ -126,16 +79,5 @@
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 3;
-  }
-
-  .touch-manipulation {
-    touch-action: manipulation;
-  }
-
-  @media (hover: hover) {
-    .mobile-card-hover:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 4px 12px -4px rgba(0, 0, 0, 0.05);
-    }
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -59,10 +59,6 @@ module.exports = {
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
-      fontFamily: {
-        sans: ["var(--font-geist-sans)", "system-ui", "sans-serif"],
-        mono: ["var(--font-geist-mono)", "monospace"],
-      },
       keyframes: {
         "accordion-down": {
           from: { height: "0" },
@@ -72,36 +68,10 @@ module.exports = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
-        shimmer: {
-          "100%": {
-            transform: "translateX(100%)",
-          },
-        },
-        fadeIn: {
-          from: { opacity: "0" },
-          to: { opacity: "1" },
-        },
-        slideUp: {
-          from: { transform: "translateY(10px)", opacity: "0" },
-          to: { transform: "translateY(0)", opacity: "1" },
-        },
-        scaleIn: {
-          from: { transform: "scale(0.95)", opacity: "0" },
-          to: { transform: "scale(1)", opacity: "1" },
-        },
-        pulse: {
-          "0%, 100%": { opacity: "1" },
-          "50%": { opacity: "0.5" },
-        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
-        shimmer: "shimmer 2s infinite",
-        fadeIn: "fadeIn 0.5s ease-out forwards",
-        slideUp: "slideUp 0.5s ease-out forwards",
-        scaleIn: "scaleIn 0.3s ease-out forwards",
-        pulse: "pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite",
       },
     },
   },


### PR DESCRIPTION
## Summary
Revert all custom colors, gradients, and premium styling back to default shadcn/ui.

## Changes
- **CSS**: Reset `index.css` to default shadcn CSS variables (purple primary, standard 0.5rem radius)
- **Tailwind**: Remove custom keyframes (`shimmer`, `fadeIn`, `slideUp`, `scaleIn`, `slideDown`, `pulse`) and font overrides from config
- **Components**: Replace all `bg-gradient-to-r` / `cyan-600` references with solid `bg-primary`
- **Card**: Change default `rounded-xl` back to `rounded-lg`
- **Badge**: Remove non-default chip variants (`chip-seeds`, `chip-size`, `chip-indexer`)
- **SearchSuggestions**: Replace glass effects and gradients with standard shadcn `shadow`/`border` classes

## Verification
- `npm run build` ✅ passes
- `npm run lint` ✅ passes