### PR TITLE
Fix: Release workflow git push authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        persist-credentials: false
 
     - name: Setup Node.js
       uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Removes persist-credentials: false from the checkout step which was breaking git push authentication, causing the release workflow to fail with:



The GITHUB_TOKEN credentials must be persisted for the git push --follow-tags origin main command in the subsequent step to work properly.