### PR TITLE
fix: update Node.js version to 22.x for semantic-release compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "postversion": "git push && git push --tags"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=22.14.0",
     "npm": ">=9"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Fixes the semantic-release Node.js version requirement error after PR #16 migrated to semantic-release v25.0.3.

The CI workflow was still using Node.js 20.x, but semantic-release v25.0.3 requires Node.js ^22.14.0 || >= 24.10.0.

## Changes
- Updated `.github/workflows/release.yml` to use `node-version: '22.x'`
- Updated `package.json` engines to require `node >= 22.14.0`